### PR TITLE
Fix printf'ing of negative values

### DIFF
--- a/option-6rd.sh
+++ b/option-6rd.sh
@@ -59,7 +59,7 @@ log_6rd() {
 
 	srd_masklen=${srd_vals[0]}
 	srd_prefixlen=${srd_vals[1]}
-	srd_prefix="`printf "%x:%x:%x:%x:%x:%x:%x:%x" ${srd_vals[@]:2:8} | sed -E s/\(:0\)+$/::/`"
+	srd_prefix="`printf "%x:%x:%x:%x:%x:%x:%x:%x" $(for x in $(seq 2 8) ; do echo $((${srd_vals[$x]} & (1 << 16) - 1)) ; done) | sed -E s/\(:0\)+$/::/`"
 	srd_braddr=${srd_vals[10]}
 	ipsep=(${new_ip_address//\./ })
 


### PR DESCRIPTION
The option_6rd may contain, and with Telia Finland currently does contain,
negative value(s), which are used to construct an address like:
 6rd-prefix 2001:2003:fffffffffffff400::/38

This will fail. Performing a bitwise-and to srd_vals makes the
value unsigned and we get the expected address 2001:2003:f400::

(The script doesn't quite work for me after this fix either,
there are some other issues I haven't figured out yet.)